### PR TITLE
fixed Windows batch files

### DIFF
--- a/agent/bin/server.bat
+++ b/agent/bin/server.bat
@@ -1,2 +1,1 @@
-REM TODO
-java -classpath <RUNTIME_CLASSPATH> com.codecommit.cccp.agent.Main
+java -classpath <RUNTIME_CLASSPATH> com.codecommit.cccp.agent.Main %*

--- a/agent/build.sbt
+++ b/agent/build.sbt
@@ -41,7 +41,7 @@ stage <<= (dependencyClasspath in Runtime, exportedProducts in Runtime) map { (d
   }
   // Expand the server invocation script templates.
   writeScript(cpLibs.mkString(":").replace("\\", "/"), "agent/bin/server", "agent/dist/bin/server")
-  writeScript("\"" + cpLibs.mkString(";").replace("/", "\\") + "\"", "agent/bin/server.bat", "agent/dist/bin/server.bat")
+  writeScript("\"" + cpLibs.map{lib => "%~dp0/../" + lib}.mkString(";").replace("/", "\\") + "\"", "agent/bin/server.bat", "agent/dist/bin/server.bat")
   // copyFile(root / "README.md", root / "dist" / "README.md")
   // copyFile(root / "LICENSE", root / "dist" / "LICENSE")
 }

--- a/server/bin/cccp-server.bat
+++ b/server/bin/cccp-server.bat
@@ -1,1 +1,1 @@
-java -classpath <RUNTIME_CLASSPATH> com.codecommit.cccp.server.Main
+java -classpath <RUNTIME_CLASSPATH> com.codecommit.cccp.server.Main %*

--- a/server/build.sbt
+++ b/server/build.sbt
@@ -41,7 +41,7 @@ stage <<= (dependencyClasspath in Runtime, exportedProducts in Runtime) map { (d
   }
   // Expand the server invocation script templates.
   writeScript(cpLibs.mkString(":").replace("\\", "/"), "server/bin/cccp-server", "server/dist/bin/cccp-server")
-  writeScript("\"" + cpLibs.mkString(";").replace("/", "\\") + "\"", "server/bin/cccp-server.bat", "server/dist/bin/cccp-server.bat")
+  writeScript("\"" + cpLibs.map{lib => "%~dp0/../" + lib}.mkString(";").replace("/", "\\") + "\"", "server/bin/cccp-server.bat", "server/dist/bin/cccp-server.bat")
   // copyFile(root / "README.md", root / "dist" / "README.md")
   // copyFile(root / "LICENSE", root / "dist" / "LICENSE")
 }


### PR DESCRIPTION
Hey!

I've fixed windows batch files to:
1) Always use an absolute path that is relative to the location of startup scripts (otherwise the script simply not worked for me)
2) Accept command-line parameters (to express that you write %\* instead of $\* in unix)

Cheers,
Eugene
