### PR TITLE
Update README with new location of cccp-emacs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ cross-editor real-time, character by character collaboration (a la SubEthaEdit,
 Gobby or Google Docs).  Support is currently provided for the following editors:
 
 * jEdit_
-* Emacs_ (via the cccp-mode_)
+* Emacs_ (via cccp-emacs_)
 
 The editor-specific plugins are extremely tiny and merely delegate all work to an
 editor-agnostic sub-process.  This means that it should be extremely easy to
@@ -478,7 +478,7 @@ again.
 
 .. _jEdit: http://jedit.org
 .. _Emacs: http://www.gnu.org/s/emacs/
-.. _cccp-mode: https://github.com/candera/cccp-mode
+.. _cccp-emacs: https://github.com/candera/cccp-emacs
 .. _SBT: https://github.com/harrah/xsbt/wiki
 .. _BlueEyes: https://github.com/jdegoes/blueeyes
 .. _Netty: http://www.jboss.org/netty


### PR DESCRIPTION
I moved cccp-mode to cccp-emacs. This change updates the README with the new name and location.
